### PR TITLE
Fix charge level sensors for storage heaters

### DIFF
--- a/custom_components/smartbox/models.py
+++ b/custom_components/smartbox/models.py
@@ -319,7 +319,7 @@ class SmartboxNode:
         otherwise from product_id. For example: "XX1CXX" -> "1C" or "081C" -> "1C"
         This mirrors the behaviour used in the official web app.
 
-        This is used to identify specific storage heater models that have
+        This is used to identify specific heater models that have
         different data structures or behaviors.
         """
         min_length = 4

--- a/custom_components/smartbox/models.py
+++ b/custom_components/smartbox/models.py
@@ -308,6 +308,39 @@ class SmartboxNode:
         return self._node_info["addr"]
 
     @property
+    def product_id(self) -> str:
+        """Return the product id of the node."""
+        return self._node_info.get("product_id", "")
+
+    def get_model_code(self) -> str:
+        """Extract the model code from version.pid or product_id.
+
+        Returns characters 3-4 (index 2-3) from version.pid if available,
+        otherwise from product_id. For example: "XX1CXX" -> "1C" or "081C" -> "1C"
+        This mirrors the behaviour used in the official web app.
+
+        This is used to identify specific storage heater models that have
+        different data structures or behaviors.
+        """
+        min_length = 4
+        model_code_start = 2
+        model_code_end = 4
+
+        version_info = self._node_info.get("version", {})
+        if isinstance(version_info, dict):
+            pid = version_info.get("pid", "")
+            if pid:
+                pid_upper = pid.upper() if pid else ""
+                if len(pid_upper) >= min_length:
+                    return pid_upper[model_code_start:model_code_end]
+
+        product_id = self.product_id.upper() if self.product_id else ""
+        if len(product_id) >= min_length:
+            return product_id[model_code_start:model_code_end]
+
+        return ""
+
+    @property
     def status(self) -> StatusDict:
         """Return the status of node."""
         return self._status

--- a/custom_components/smartbox/sensor.py
+++ b/custom_components/smartbox/sensor.py
@@ -353,7 +353,17 @@ class ChargeLevelSensor(SmartboxSensorBase):
     @property
     def native_value(self) -> int:
         """Return the native value of the sensor."""
-        return self._status["charge_level"]
+        # Different storage heater models use different field names for charge level
+        # Model 1C storage heaters use 'current_charge_per'
+        # Other storage heater models use 'charge_level' directly
+        model_code = self._node.get_model_code()
+
+        if model_code == "1C":
+            # Model 1C storage heaters: use current_charge_per field
+            return self._status.get("current_charge_per", 0)
+
+        # Default for other storage heater models: use charge_level field
+        return self._status.get("charge_level", 0)
 
 
 class BoostEndTimeSensor(SmartboxSensorBase):

--- a/custom_components/smartbox/sensor.py
+++ b/custom_components/smartbox/sensor.py
@@ -343,7 +343,7 @@ class TotalConsumptionSensor(SmartboxSensorBase):
 
 
 class ChargeLevelSensor(SmartboxSensorBase):
-    """Smartbox storage heater charge level sensor."""
+    """Smartbox heater charge level sensor."""
 
     _attr_key = "charge_level"
     device_class = SensorDeviceClass.BATTERY
@@ -353,16 +353,14 @@ class ChargeLevelSensor(SmartboxSensorBase):
     @property
     def native_value(self) -> int:
         """Return the native value of the sensor."""
-        # Different storage heater models use different field names for charge level
-        # Model 1C storage heaters use 'current_charge_per'
-        # Other storage heater models use 'charge_level' directly
+        # Different heater models use different field names for charge level
+        # Returns 'current_charge_per' if model == 1C (storage heaters)
+        # Other heater models use 'charge_level' directly
         model_code = self._node.get_model_code()
 
         if model_code == "1C":
-            # Model 1C storage heaters: use current_charge_per field
             return self._status.get("current_charge_per", 0)
 
-        # Default for other storage heater models: use charge_level field
         return self._status.get("charge_level", 0)
 
 

--- a/custom_components/smartbox/sensor.py
+++ b/custom_components/smartbox/sensor.py
@@ -343,7 +343,7 @@ class TotalConsumptionSensor(SmartboxSensorBase):
 
 
 class ChargeLevelSensor(SmartboxSensorBase):
-    """Smartbox heater charge level sensor."""
+    """Smartbox storage heater charge level sensor."""
 
     _attr_key = "charge_level"
     device_class = SensorDeviceClass.BATTERY

--- a/tests/const.py
+++ b/tests/const.py
@@ -63,6 +63,9 @@ MOCK_SMARTBOX_NODE_INFO = {
             "product_id": "product_id_1_1",
             "fw_version": "fw_version_1_1",
             "serial_id": "serial_id_1_1",
+            "version": {
+                "pid": "081c",
+            },
         },
     ],
     "device_2": [
@@ -235,7 +238,9 @@ MOCK_SMARTBOX_NODE_STATUS: dict[str, list[dict[str, Any]]] = {
             "locked": False,
             # acm nodes have a 'charging' state rather than 'active'
             "charging": True,
-            "charge_level": 2,
+            # Model 1C uses current_charge_per instead of charge_level
+            "current_charge_per": 15,
+            "target_charge_per": 25,
             "power": "620",
             "mode": "auto",
         },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -268,9 +268,9 @@ async def test_basic_charge_level(hass, mock_smartbox, recorder_mock, config_ent
             )
             assert state.attributes[ATTR_LOCKED] == mock_node_status["locked"]
 
-            # Calculate expected charge level based on storage heater model type
-            # Model 1C storage heaters use current_charge_per
-            # Other storage heater models use charge_level directly
+            # Calculate expected charge level based on heater model type
+            # Model 1C (storage heaters) use current_charge_per
+            # Other heater models use charge_level directly
 
             # Extract model code from version.pid (preferred) or product_id (fallback)
             version_info = mock_node.get("version", {})
@@ -294,14 +294,14 @@ async def test_basic_charge_level(hass, mock_smartbox, recorder_mock, config_ent
             assert int(state.state) == pytest.approx(int(expected_charge))
 
             # Update charge level via socket
-            # Use appropriate field based on storage heater model type
+            # Use appropriate field based on heater model type
             if model_code == "1C":
-                # Model 1C storage heaters: update current_charge_per
+                # Model 1C heaters: update current_charge_per
                 mock_smartbox.generate_socket_status_update(
                     mock_device, mock_node, {"current_charge_per": 5}
                 )
             else:
-                # Other storage heater models: update charge_level directly
+                # Other heater models: update charge_level directly
                 mock_smartbox.generate_socket_status_update(
                     mock_device, mock_node, {"charge_level": 5}
                 )


### PR DESCRIPTION
The charge level sensors weren't working for my storage heaters. Turns out different models use different field names for reporting charge levels - the integration was only checking for `charge_level`, but my heaters (with PID `081c`) use `current_charge_per` instead.

I deobfuscated the official web app's JavaScript to see how they handle this:

```javascript
function getChargeLevel(data) {
  if (!data || !data.status) {
    return 0;
  }
  switch (((data.version || {}).pid || '').toUpperCase().slice(2, 4)) {
    case '1C':
      return data.status.current_charge_per;
    default:
      return data.status.charge_level;
  }
}
```

So they extract characters 3-4 from the PID to identify the model type. Models with code `1C` use `current_charge_per`, everything else uses `charge_level`.

## Changes

I've added a `get_model_code()` helper method in `models.py` that extracts the model code from `version.pid` (or falls back to `product_id`, the current behaviour). The `ChargeLevelSensor` now uses this to pick the right field name based on the model.

Here's what the data looks like from my actual devices:

```json
{
  "version": {
    "hw_version": "1.0",
    "fw_version": "1.6",
    "pid": "081c"
  },
  "status": {
    "mode": "auto",
    "charging": false,
    "current_charge_per": 28,
    "target_charge_per": 28,
    "mtemp": "19.3",
    "stemp": "21.0"
  }
}
```

This is fully backwards compatible - existing storage heaters using `charge_level` continue to work unchanged.

I've tested these changes in my HA instance and the error messages appear to be gone.
