### PR TITLE
Fix charge level sensor for PID 1C storage heaters

### DIFF
--- a/custom_components/smartbox/sensor.py
+++ b/custom_components/smartbox/sensor.py
@@ -353,7 +353,13 @@ class ChargeLevelSensor(SmartboxSensorBase):
     @property
     def native_value(self) -> int:
         """Return the native value of the sensor."""
-        return self._status["charge_level"]
+        # Different heater models use different field names for charge level
+        # Returns 'current_charge_per' if model == 1C (storage heaters)
+        # Other heater models use 'charge_level' directly
+        model_code = self._node.get_model_code()
+        if model_code == "1C":
+            return self._status.get("current_charge_per", 0)
+        return self._status.get("charge_level", 0)
 
 
 class BoostEndTimeSensor(SmartboxSensorBase):


### PR DESCRIPTION
The charge level sensors weren't working for my storage heaters. Turns out different models use different field names for reporting charge levels - the integration was only checking for charge_level, but my heaters (with PID 081c) use current_charge_per instead.

I deobfuscated the official web app's JavaScript to see how they handle this:

```js
function getChargeLevel(data) {
  if (!data || !data.status) {
    return 0;
  }
  switch (((data.version || {}).pid || '').toUpperCase().slice(2, 4)) {
    case '1C':
      return data.status.current_charge_per;
    default:
      return data.status.charge_level;
  }
}
```

So they extract characters 3-4 from the PID to identify the model type. Models with code 1C use `current_charge_per`, everything else continues uses `charge_level`.


Important: these changes require https://github.com/ajtudela/smartbox/pull/40 being merged first to make sure the Product ID field is available to read from.